### PR TITLE
migrate winapi to windows-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ hex = "0.4"
 hyper = { version = "1.1", features = ["client", "http1"] }
 hyper-util = { version = "0.1.2", features = ["http1", "client-legacy", "tokio"] }
 pin-project-lite = { version = "0.2.8" }
-winapi = { version = "0.3.9", features = ["winerror"] }
 tokio = { version = "1.35", features = ["net"] }
 tower-service = { version = "0.3" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hyper-named-pipe"
 description = "Hyper client bindings for Windows Named Pipes"
-version = "0.1.0"
+version = "0.1.1"
 license = "Apache-2.0"
 homepage = "https://github.com/fussybeaver/hyper-named-pipe"
 repository = "https://github.com/fussybeaver/hyper-named-pipe"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2017
+image: Visual Studio 2022
 
 environment:
   matrix:
@@ -23,6 +23,7 @@ install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init -yv --default-toolchain %channel% --default-host %target%
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
+  - if not "%target:windows-gnu=%"=="%target%" set PATH=C:\msys64\mingw64\bin;%PATH%
   - rustc -vV
   - cargo -vV
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,8 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
-use winapi::shared::winerror;
+/// The windows error constant for a busy named pipe.
+const ERROR_PIPE_BUSY: u32 = 231u32;
 
 /// The scheme part of a uri that denotes a named pipe connection
 pub const NAMED_PIPE_SCHEME: &str = "net.pipe";
@@ -106,7 +107,7 @@ impl NamedPipeStream {
         let client = loop {
             match opts.open(&addr) {
                 Ok(client) => break client,
-                Err(e) if e.raw_os_error() == Some(winerror::ERROR_PIPE_BUSY as i32) => (),
+                Err(e) if e.raw_os_error() == Some(ERROR_PIPE_BUSY as i32) => (),
                 Err(e) => return Err(e),
             };
 


### PR DESCRIPTION
The `winapi` crate is unmaintained, so this removes the dependency and defines the equivalent `ERROR_PIPE_BUSY` constant locally.

The AppVeyor configuration is also updated to use the Visual Studio 2022 image and add the MSYS2 MinGW tools to `PATH` for GNU targets, ensuring `dlltool.exe` is available.

This preserves the existing MSVC and GNU Windows test matrix.

Requires [fussybeaver/bollard#725](https://github.com/fussybeaver/bollard/pull/725) to fully resolve [fussybeaver/bollard#723](https://github.com/fussybeaver/bollard/issues/723).